### PR TITLE
Change applications to extra_applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ end
 
 2. Run `$ mix deps.get` to update your dependencies.
 
-3. Add `:lix` to your applications list:
+3. Add `:lix` to your extra applications list:
 
 ```elixir
 def application do
-  [applications: [:lix]]
+  [extra_applications: [:lix]]
 end
 ```
 


### PR DESCRIPTION
In `mix.exs` files, applications from external dependencies should either be defined in `extra_applications` or not defined at all.

This is because Elixir automatically discovers the applications in dependencies and appends them to the `applications` key, unless, we explicitly set it (as is currently suggested in the README.md file). If we want to add an application, we can either add it to the `extra_applications` key, which is *not* inferred by Elixir, or we can not add it at all.

If we explicitly set the application key, we are disabling the inferring of the application list, which could break dependencies which say to not add to that list.

This PR resolves this potential issue by recommending users to add the library to the `extra_applications` list.