### PR TITLE
Add name and source_url for Hex.pm

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,9 @@ defmodule Lix.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
-      description: description()
+      description: description(),
+      name: "lix",
+      source_url: "https://github.com/rfunix/lix"
     ]
   end
 


### PR DESCRIPTION
lix is already in hex.pm:

https://hexdocs.pm/lix/0.1.0/api-reference.html

Please merge this PR, hex needs a name and a source_url